### PR TITLE
Avro to Json conversion and test

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -8,6 +8,7 @@ license: MIT
 homepage: https://github.com/packetloop/topictap#readme
 extra-source-files:
 - README.md
+- tests/resources/simple.avsc
 default-extensions:
 - OverloadedStrings
 - TupleSections
@@ -51,6 +52,7 @@ library:
   - App.Kafka
   - App.Options
   dependencies:
+  - base64-bytestring
   - conduit-combinators
   - http-types
   - optparse-applicative
@@ -87,9 +89,13 @@ tests:
     - -Wall
     - -threaded
     dependencies:
-    - topictap
-    - hspec
+    - base64-bytestring
     - hedgehog
+    - hspec
+    - hw-hedgehog
+    - hw-hspec-hedgehog
+    - lens-aeson
+    - topictap
     when:
     - condition: os(osx)
       cpp-options:

--- a/src/App/AvroToJson.hs
+++ b/src/App/AvroToJson.hs
@@ -2,24 +2,27 @@ module App.AvroToJson where
 
 import Data.Avro ()
 
-import qualified Data.Aeson       as J
-import qualified Data.Avro.Schema as S
-import qualified Data.Avro.Types  as T
+import qualified Data.Aeson             as J
+import qualified Data.Avro.Schema       as S
+import qualified Data.Avro.Types        as A
+import qualified Data.ByteString.Base64 as B64
+import qualified Data.Text.Encoding     as T
 
-avroToJson :: T.Value S.Type -> J.Value
-avroToJson T.Null          = J.Null
-avroToJson (T.Boolean v)   = J.Bool v
-avroToJson (T.String v)    = J.String v
-avroToJson (T.Int v)       = J.Number . fromRational . toRational $ v
-avroToJson (T.Long v)      = J.Number . fromRational . toRational $ v
-avroToJson (T.Double v)    = J.Number . fromRational . toRational $ v
+avroToJson :: A.Value S.Type -> J.Value
+avroToJson A.Null          = J.Null
+avroToJson (A.Boolean v)   = J.Bool v
+avroToJson (A.String v)    = J.String v
+avroToJson (A.Int v)       = J.Number . fromRational . toRational $ v
+avroToJson (A.Long v)      = J.Number . fromRational . toRational $ v
+avroToJson (A.Double v)    = J.Number . fromRational . toRational $ v
+avroToJson (A.Float v)     = J.Number . fromRational . toRational $ v
 
-avroToJson (T.Record _ v)  = J.Object $ avroToJson <$> v
-avroToJson (T.Array v)     = J.Array  $ avroToJson <$> v
-avroToJson (T.Map v)       = J.Object $ avroToJson <$> v
-avroToJson (T.Enum _ _ v)  = J.String v
+avroToJson (A.Record _ v)  = J.Object $ avroToJson <$> v
+avroToJson (A.Array v)     = J.Array  $ avroToJson <$> v
+avroToJson (A.Map v)       = J.Object $ avroToJson <$> v
+avroToJson (A.Enum _ _ v)  = J.String v
 
-avroToJson (T.Union _ _ v) = avroToJson v
-avroToJson (T.Fixed _)     = error "Not Implemented Fixed"
-avroToJson (T.Float _)     = error "Not Implemented Float"
-avroToJson (T.Bytes _)     = error "Not Implemented Bytes"
+avroToJson (A.Union _ _ v) = avroToJson v
+
+avroToJson (A.Fixed v)     = J.String $ T.decodeUtf8 (B64.encode v)
+avroToJson (A.Bytes v)     = J.String $ T.decodeUtf8 (B64.encode v)

--- a/tests/App/AvroToJsonSpec.hs
+++ b/tests/App/AvroToJsonSpec.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell    #-}
+
+module App.AvroToJsonSpec
+  ( spec
+  ) where
+
+import Control.Lens
+import Data.Aeson.Lens
+import Data.Avro
+import Data.Avro.Deriving
+import Data.Text          (Text)
+
+import qualified Data.ByteString.Base64 as B64
+import qualified Data.Text              as T
+import qualified Data.Text.Encoding     as T
+
+import App.AvroToJson
+
+import Test.Hspec
+
+import           HaskellWorks.Hspec.Hedgehog
+import           Hedgehog
+import qualified Hedgehog.Gen                as G
+import qualified Hedgehog.Range              as R
+
+{-# ANN module ("HLint: ignore Redundant do"  :: String) #-}
+
+deriveAvro "tests/resources/simple.avsc"
+
+eitherGen :: MonadGen m => m a -> m b -> m (Either a b)
+eitherGen genA genB = G.choice [Left <$> genA, Right <$> genB]
+
+smallStringGen :: MonadGen m => m Text
+smallStringGen = G.text (R.linear 0 125) G.unicode
+
+simpleRecordGen :: MonadGen m => m SimpleRecord
+simpleRecordGen = SimpleRecord
+  <$> G.bool
+  <*> smallStringGen
+  <*> G.int R.constantBounded
+  <*> G.int64 R.constantBounded
+  <*> G.double (R.linearFrac (-12345) 12345)
+  <*> G.bytes (R.linear 0 125)
+  <*> G.maybe smallStringGen
+  <*> eitherGen (G.int R.constantBounded) smallStringGen
+  <*> G.enum SuitSPADES SuitCLUBS
+  <*> (InnerRecord <$> G.int R.constantBounded <*> smallStringGen)
+
+spec :: Spec
+spec = describe "App.AvroToJsonSpec" $ do
+  it "should format json" $ require $ property $ do
+    value <- forAll simpleRecordGen
+    let res = avroToJson (toAvro value)
+    res ^? key "boolean" . _Bool     === Just (simpleRecordBoolean value)
+    res ^? key "string"  . _String   === Just (simpleRecordString value)
+    res ^? key "int"     . _Integral === Just (simpleRecordInt value)
+    res ^? key "long"    . _Integral === Just (simpleRecordLong value)
+    res ^? key "double"  . _Double   === Just (simpleRecordDouble value)
+    res ^? key "bytes"   . _String   === Just (T.decodeUtf8 $ B64.encode $ simpleRecordBytes value)
+    res ^? key "maybe"   . _String   === simpleRecordMaybe value
+
+    ((res ^? key "enum" . _String) <&> (mappend "Suit")) === Just (T.pack . show $ simpleRecordEnum value)
+
+    case simpleRecordEither value of
+      Left a  -> res ^? key "either" . _Integral === Just a
+      Right b -> res ^? key "either" . _String === Just b
+
+    res ^? key "record" . _Value . key "id" . _Integral === Just (innerRecordId $ simpleRecordRecord value)
+    res ^? key "record" . _Value . key "value" . _String === Just (innerRecordValue $ simpleRecordRecord value)
+
+

--- a/tests/resources/simple.avsc
+++ b/tests/resources/simple.avsc
@@ -1,0 +1,33 @@
+{
+  "type": "record",
+  "name": "SimpleRecord",
+  "fields": [
+    { "name": "boolean", "type": "boolean"   },
+    { "name": "string", "type": "string"  },
+    { "name": "int",    "type": "int"     },
+    { "name": "long",   "type": "long"    },
+    { "name": "double", "type": "double"  },
+    { "name": "bytes",  "type": "bytes"   },
+    { "name": "maybe",  "type": ["null", "string"]  },
+    { "name": "either", "type": ["int", "string"]   },
+    {
+      "name": "enum",
+      "type": {
+        "type": "enum",
+        "name": "Suit",
+        "symbols" : ["SPADES", "HEARTS", "DIAMONDS", "CLUBS"]
+      }
+    },
+    {
+      "name": "record",
+      "type": {
+        "name": "InnerRecord",
+        "type": "record",
+        "fields": [
+          { "name": "id",    "type": "int"    },
+          { "name": "value", "type": "string" }
+        ]
+      }
+    }
+  ]
+}

--- a/topictap.cabal
+++ b/topictap.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: cf14574f724b9857a7fa9dfe13c59d2f7e2e74fbf285ff9ba03786cd69ca5c32
+-- hash: 8d3cd146ee74f278ba400d322070fc59fa8e2f100abadd64cef44add93edc03f
 
 name:           topictap
 version:        1.0.0
@@ -18,6 +18,7 @@ cabal-version:  >= 1.10
 
 extra-source-files:
     README.md
+    tests/resources/simple.avsc
 
 library
   hs-source-dirs:
@@ -28,6 +29,7 @@ library
       aeson
     , avro
     , base >=4.7 && <5
+    , base64-bytestring
     , bifunctors
     , bytestring
     , conduit
@@ -124,6 +126,7 @@ test-suite tests
       aeson
     , avro
     , base >=4.7 && <5
+    , base64-bytestring
     , bifunctors
     , bytestring
     , conduit
@@ -136,10 +139,13 @@ test-suite tests
     , hs-arbor-logger
     , hspec
     , hw-conduit
+    , hw-hedgehog
+    , hw-hspec-hedgehog
     , hw-kafka-avro
     , hw-kafka-client
     , hw-kafka-conduit
     , lens
+    , lens-aeson
     , monad-control
     , monad-logger
     , mtl
@@ -153,6 +159,7 @@ test-suite tests
   if os(osx)
     cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull=
   other-modules:
+      App.AvroToJsonSpec
       App.OptionsSpec
       Paths_topictap
   default-language: Haskell2010


### PR DESCRIPTION
## Changes
- Finish `avroToJson`
- Property test

### Findings
Current implementation of `avro` have two issues that are to be fixed:
- `fixed` type is not properly supported, at least not by `deriveAvro`, but I suspect that the issue is deeper.
- There is no instance `ToAvro Float`. Probably `FromAvro Float` is also missing, but I haven't checked. 