### PR TITLE
Has module

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -34,6 +34,7 @@ import System.IO.Error                      (ioeGetErrorType, isDoesNotExistErro
 
 import qualified Antiope.Env          as AWS
 import qualified App.AppState.Lens    as L
+import qualified App.Lens             as L
 import qualified Arbor.Logger         as Log
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map             as M
@@ -106,11 +107,11 @@ main = do
         consumer <- mkConsumer Nothing (opt ^. optInputTopics) (const (pushLogMessage lgr LevelWarn ("Rebalance is in progress!" :: String)))
 
         logInfo "Instantiating Schema Registry"
-        sr <- schemaRegistry (kafkaConf ^. schemaRegistryAddress)
+        sr <- schemaRegistry (kafkaConf ^. L.schemaRegistryAddress)
 
         logInfo "Running Kafka Consumer"
         runConduit $
-          kafkaSourceNoClose consumer (kafkaConf ^. pollTimeoutMs)
+          kafkaSourceNoClose consumer (kafkaConf ^. L.pollTimeoutMs)
           .| throwLeftSatisfy isFatal                      -- throw any fatal error
           .| skipNonFatalExcept [isPollTimeout]            -- discard any non-fatal except poll timeouts
           .| rightC (handleStream sr (opt ^. optStagingDirectory))

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -128,14 +128,14 @@ main = do
 withStatsClient :: AppName -> StatsConfig -> (StatsClient -> IO ()) -> IO ()
 withStatsClient appName statsConf f = do
   globalTags <- mkStatsTags statsConf
-  let statsOpts = DogStatsSettings (statsConf ^. statsHost) (statsConf ^. statsPort)
+  let statsOpts = DogStatsSettings (statsConf ^. L.host) (statsConf ^. L.port)
   bracket (createStatsClient statsOpts (MetricName appName) globalTags) closeStatsClient f
 
 mkStatsTags :: StatsConfig -> IO [Tag]
 mkStatsTags statsConf = do
   deplId <- envTag "TASK_DEPLOY_ID" "deploy_id"
   let envTags = catMaybes [deplId]
-  return $ envTags <> (statsConf ^. statsTags <&> toTag)
+  return $ envTags <> (statsConf ^. L.tags <&> toTag)
   where
     toTag (StatsTag (k, v)) = S.tag k v
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -34,6 +34,7 @@ import System.IO.Error                      (ioeGetErrorType, isDoesNotExistErro
 
 import qualified Antiope.Env          as AWS
 import qualified App.AppState.Lens    as L
+import qualified App.Has              as H
 import qualified App.Lens             as L
 import qualified Arbor.Logger         as Log
 import qualified Data.ByteString.Lazy as LBS
@@ -115,7 +116,7 @@ main = do
           .| throwLeftSatisfy isFatal                      -- throw any fatal error
           .| skipNonFatalExcept [isPollTimeout]            -- discard any non-fatal except poll timeouts
           .| rightC (handleStream sr (opt ^. optStagingDirectory))
-          .| sampleC (opt ^. storeUploadInterval)
+          .| sampleC (opt ^. H.storeConfig . L.uploadInterval)
           .| effectC' (logInfo "Uploading files...")
           .| effectC (\(t, _) -> uploadAllFiles ctoken t)
           .| effectC' (logInfo "Uploading completed")

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -85,7 +85,7 @@ main = do
   withStdOutTimedFastLogger $ \lgr -> do
     withStatsClient progName statsConf $ \stats -> do
       let envLogger = AppLogger lgr logLvl
-      envAws <- mkEnv (opt ^. awsRegion) (logAWS envLogger)
+      envAws <- mkEnv (opt ^. H.awsConfig . L.region) (logAWS envLogger)
       let envApp = AppEnv opt stats envLogger envAws
 
       void . runApplication envApp $ do

--- a/package.yaml
+++ b/package.yaml
@@ -94,6 +94,7 @@ library:
   - App.CancellationToken
   - App.Codec
   - App.Conduit.Time
+  - App.Has
   - App.Kafka
   - App.Lens
   - App.Options

--- a/package.yaml
+++ b/package.yaml
@@ -95,6 +95,7 @@ library:
   - App.Codec
   - App.Conduit.Time
   - App.Kafka
+  - App.Lens
   - App.Options
   - App.Persist
   - App.Service

--- a/src/App/AppEnv.hs
+++ b/src/App/AppEnv.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses  #-}
 {-# LANGUAGE TemplateHaskell        #-}
-module App.AppEnv
-where
 
-import Antiope.Env    (Env, HasEnv (..))
+module App.AppEnv where
+
+import Antiope.Env    (Env)
 import App.Options
 import Arbor.Logger   (LogLevel, TimedFastLogger)
 import Control.Lens
@@ -24,30 +24,3 @@ data AppEnv = AppEnv
 
 makeClassy ''AppLogger
 makeClassy ''AppEnv
-
-instance HasEnv AppEnv where
-  environment = appEnvAws
-
-class HasStatsClient a where
-  statsClient :: Lens' a StatsClient
-
-instance HasStatsClient StatsClient where
-  statsClient = id
-
-instance HasStatsClient AppEnv where
-  statsClient = appStatsClient
-
-instance HasKafkaConfig AppEnv where
-  kafkaConfig = appOptions . kafkaConfig
-
-instance HasStatsConfig AppEnv where
-  statsConfig = appOptions . statsConfig
-
-instance HasAppLogger AppEnv where
-  appLogger = appEnv . appLog
-
-instance HasAwsConfig AppEnv where
-  awsConfig = appOptions . optAwsConfig
-
-instance HasStoreConfig AppEnv where
-  storeConfig = appOptions . optStoreConfig

--- a/src/App/AppEnv.hs
+++ b/src/App/AppEnv.hs
@@ -16,7 +16,7 @@ data AppLogger = AppLogger
   }
 
 data AppEnv = AppEnv
-  { _appOptions     :: Options
+  { _appOptions     :: AppOptions
   , _appStatsClient :: StatsClient
   , _appLog         :: AppLogger
   , _appEnvAws      :: Env

--- a/src/App/AppEnv.hs
+++ b/src/App/AppEnv.hs
@@ -16,11 +16,10 @@ data AppLogger = AppLogger
   }
 
 data AppEnv = AppEnv
-  { _appOptions     :: AppOptions
-  , _appStatsClient :: StatsClient
-  , _appLog         :: AppLogger
-  , _appEnvAws      :: Env
+  { _appEnvOptions     :: AppOptions
+  , _appEnvStatsClient :: StatsClient
+  , _appEnvLog         :: AppLogger
+  , _appEnvAws         :: Env
   }
 
 makeClassy ''AppLogger
-makeClassy ''AppEnv

--- a/src/App/Application.hs
+++ b/src/App/Application.hs
@@ -13,7 +13,6 @@ module App.Application
 import Antiope.Core                 (AWS, MonadAWS, runAWS)
 import App.AppEnv
 import App.AppState.Type
-import App.Options
 import App.Orphans                  ()
 import Arbor.Logger
 import Control.Lens
@@ -27,7 +26,8 @@ import Control.Monad.Trans.Resource
 import Data.Text                    (Text)
 import Network.StatsD               as S
 
-import qualified App.Has as H ()
+import qualified App.Has  as H ()
+import qualified App.Lens as L
 
 type AppName = Text
 
@@ -66,7 +66,7 @@ runApplication :: AppEnv -> Application () -> IO AppState
 runApplication envApp f =
   runResourceT
     . runAWS envApp
-    . runTimedLogT (envApp ^. appOptions . optLogLevel) (envApp ^. appLog . alLogger)
+    . runTimedLogT (envApp ^. appOptions . L.logLevel) (envApp ^. appLog . alLogger)
     . flip execStateT appStateEmpty
     $ do
         logInfo $ show (envApp ^. appOptions)

--- a/src/App/Application.hs
+++ b/src/App/Application.hs
@@ -27,6 +27,8 @@ import Control.Monad.Trans.Resource
 import Data.Text                    (Text)
 import Network.StatsD               as S
 
+import qualified App.Has as H ()
+
 type AppName = Text
 
 class ( MonadReader AppEnv m

--- a/src/App/Application.hs
+++ b/src/App/Application.hs
@@ -60,14 +60,14 @@ newtype Application a = Application
 deriving instance MonadApp Application
 
 instance MonadStats Application where
-  getStatsClient = reader _appStatsClient
+  getStatsClient = reader _appEnvStatsClient
 
 runApplication :: AppEnv -> Application () -> IO AppState
 runApplication envApp f =
   runResourceT
     . runAWS envApp
-    . runTimedLogT (envApp ^. appOptions . L.logLevel) (envApp ^. appLog . alLogger)
+    . runTimedLogT (envApp ^. L.options . L.logLevel) (envApp ^. L.log . alLogger)
     . flip execStateT appStateEmpty
     $ do
-        logInfo $ show (envApp ^. appOptions)
+        logInfo $ show (envApp ^. L.options)
         runReaderT (unApp f) envApp

--- a/src/App/Has.hs
+++ b/src/App/Has.hs
@@ -14,6 +14,9 @@ instance HasEnv AppEnv where
 class HasStatsClient a where
   statsClient :: Lens' a StatsClient
 
+class HasKafkaConfig a where
+  kafkaConfig :: Lens' a KafkaConfig
+
 instance HasStatsClient StatsClient where
   statsClient = id
 

--- a/src/App/Has.hs
+++ b/src/App/Has.hs
@@ -3,59 +3,83 @@
 module App.Has where
 
 import Antiope.Env    (HasEnv (..))
-import App.AppEnv
 import App.Options
 import Control.Lens
+import Data.Function  (id)
 import Network.StatsD (StatsClient)
 
-instance HasEnv AppEnv where
-  environment = appEnvAws
+import qualified App.AppEnv as E
+import qualified App.Lens   as L
+
+instance HasEnv E.AppEnv where
+  environment = E.appEnvAws
 
 class HasStatsClient a where
   statsClient :: Lens' a StatsClient
 
+instance HasStatsClient StatsClient where
+  statsClient = id
+
 class HasKafkaConfig a where
   kafkaConfig :: Lens' a KafkaConfig
+
+instance HasKafkaConfig KafkaConfig where
+  kafkaConfig = id
 
 class HasStatsConfig a where
   statsConfig :: Lens' a StatsConfig
 
+instance HasStatsConfig StatsConfig where
+  statsConfig = id
+
 class HasStoreConfig a where
   storeConfig :: Lens' a StoreConfig
+
+instance HasStoreConfig StoreConfig where
+  storeConfig = id
 
 class HasAwsConfig a where
   awsConfig :: Lens' a AwsConfig
 
-instance HasStatsClient StatsClient where
-  statsClient = id
+instance HasAwsConfig AwsConfig where
+  awsConfig = id
 
-instance HasStatsClient AppEnv where
-  statsClient = appStatsClient
+class HasAppOptions a where
+  appOptions :: Lens' a AppOptions
 
-instance HasKafkaConfig AppEnv where
-  kafkaConfig = appOptions . kafkaConfig
+instance HasAppOptions AppOptions where
+  appOptions = id
 
-instance HasStatsConfig AppEnv where
-  statsConfig = appOptions . statsConfig
 
-instance HasAppLogger AppEnv where
-  appLogger = appEnv . appLog
 
-instance HasAwsConfig AppEnv where
-  awsConfig = appOptions . optAwsConfig
+instance HasStatsClient E.AppEnv where
+  statsClient = E.appStatsClient
 
-instance HasStoreConfig AppEnv where
-  storeConfig = appOptions . optStoreConfig
+instance HasKafkaConfig E.AppEnv where
+  kafkaConfig = E.appOptions . kafkaConfig
 
-instance HasKafkaConfig Options where
-  kafkaConfig = optKafkaConfig
+instance HasStatsConfig E.AppEnv where
+  statsConfig = E.appOptions . statsConfig
 
-instance HasStatsConfig Options where
-  statsConfig = optStatsConfig
 
-instance HasStoreConfig Options where
-  storeConfig = optStoreConfig
+instance E.HasAppLogger E.AppEnv where
+  appLogger = E.appEnv . E.appLog
 
-instance HasAwsConfig Options where
-  awsConfig = optAwsConfig
+instance HasAwsConfig E.AppEnv where
+  awsConfig = E.appOptions . awsConfig
+
+instance HasStoreConfig E.AppEnv where
+  storeConfig = E.appOptions . storeConfig
+
+instance HasKafkaConfig AppOptions where
+  kafkaConfig = L.kafkaConfig
+
+instance HasStatsConfig AppOptions where
+  statsConfig = L.statsConfig
+
+instance HasStoreConfig AppOptions where
+  storeConfig = L.storeConfig
+
+instance HasAwsConfig AppOptions where
+  awsConfig = L.awsConfig
 

--- a/src/App/Has.hs
+++ b/src/App/Has.hs
@@ -1,0 +1,49 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module App.Has where
+
+import Antiope.Env    (HasEnv (..))
+import App.AppEnv
+import App.Options
+import Control.Lens
+import Network.StatsD (StatsClient)
+
+instance HasEnv AppEnv where
+  environment = appEnvAws
+
+class HasStatsClient a where
+  statsClient :: Lens' a StatsClient
+
+instance HasStatsClient StatsClient where
+  statsClient = id
+
+instance HasStatsClient AppEnv where
+  statsClient = appStatsClient
+
+instance HasKafkaConfig AppEnv where
+  kafkaConfig = appOptions . kafkaConfig
+
+instance HasStatsConfig AppEnv where
+  statsConfig = appOptions . statsConfig
+
+instance HasAppLogger AppEnv where
+  appLogger = appEnv . appLog
+
+instance HasAwsConfig AppEnv where
+  awsConfig = appOptions . optAwsConfig
+
+instance HasStoreConfig AppEnv where
+  storeConfig = appOptions . optStoreConfig
+
+instance HasKafkaConfig Options where
+  kafkaConfig = optKafkaConfig
+
+instance HasStatsConfig Options where
+  statsConfig = optStatsConfig
+
+instance HasStoreConfig Options where
+  storeConfig = optStoreConfig
+
+instance HasAwsConfig Options where
+  awsConfig = optAwsConfig
+

--- a/src/App/Has.hs
+++ b/src/App/Has.hs
@@ -12,7 +12,7 @@ import qualified App.AppEnv as E
 import qualified App.Lens   as L
 
 instance HasEnv E.AppEnv where
-  environment = E.appEnvAws
+  environment = L.aws
 
 class HasStatsClient a where
   statsClient :: Lens' a StatsClient
@@ -53,23 +53,23 @@ instance HasAppOptions AppOptions where
 
 
 instance HasStatsClient E.AppEnv where
-  statsClient = E.appStatsClient
+  statsClient = L.statsClient
 
 instance HasKafkaConfig E.AppEnv where
-  kafkaConfig = E.appOptions . kafkaConfig
+  kafkaConfig = L.options . kafkaConfig
 
 instance HasStatsConfig E.AppEnv where
-  statsConfig = E.appOptions . statsConfig
+  statsConfig = L.options . statsConfig
 
 
 instance E.HasAppLogger E.AppEnv where
-  appLogger = E.appEnv . E.appLog
+  appLogger = L.log
 
 instance HasAwsConfig E.AppEnv where
-  awsConfig = E.appOptions . awsConfig
+  awsConfig = L.options . awsConfig
 
 instance HasStoreConfig E.AppEnv where
-  storeConfig = E.appOptions . storeConfig
+  storeConfig = L.options . storeConfig
 
 instance HasKafkaConfig AppOptions where
   kafkaConfig = L.kafkaConfig

--- a/src/App/Has.hs
+++ b/src/App/Has.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module App.Has where
@@ -5,7 +6,6 @@ module App.Has where
 import Antiope.Env    (HasEnv (..))
 import App.Options
 import Control.Lens
-import Data.Function  (id)
 import Network.StatsD (StatsClient)
 
 import qualified App.AppEnv as E
@@ -14,43 +14,12 @@ import qualified App.Lens   as L
 instance HasEnv E.AppEnv where
   environment = L.aws
 
-class HasStatsClient a where
-  statsClient :: Lens' a StatsClient
-
-instance HasStatsClient StatsClient where
-  statsClient = id
-
-class HasKafkaConfig a where
-  kafkaConfig :: Lens' a KafkaConfig
-
-instance HasKafkaConfig KafkaConfig where
-  kafkaConfig = id
-
-class HasStatsConfig a where
-  statsConfig :: Lens' a StatsConfig
-
-instance HasStatsConfig StatsConfig where
-  statsConfig = id
-
-class HasStoreConfig a where
-  storeConfig :: Lens' a StoreConfig
-
-instance HasStoreConfig StoreConfig where
-  storeConfig = id
-
-class HasAwsConfig a where
-  awsConfig :: Lens' a AwsConfig
-
-instance HasAwsConfig AwsConfig where
-  awsConfig = id
-
-class HasAppOptions a where
-  appOptions :: Lens' a AppOptions
-
-instance HasAppOptions AppOptions where
-  appOptions = id
-
-
+makeClassy ''StatsClient
+makeClassy ''KafkaConfig
+makeClassy ''StatsConfig
+makeClassy ''StoreConfig
+makeClassy ''AwsConfig
+makeClassy ''AppOptions
 
 instance HasStatsClient E.AppEnv where
   statsClient = L.statsClient
@@ -60,7 +29,6 @@ instance HasKafkaConfig E.AppEnv where
 
 instance HasStatsConfig E.AppEnv where
   statsConfig = L.options . statsConfig
-
 
 instance E.HasAppLogger E.AppEnv where
   appLogger = L.log
@@ -82,4 +50,3 @@ instance HasStoreConfig AppOptions where
 
 instance HasAwsConfig AppOptions where
   awsConfig = L.awsConfig
-

--- a/src/App/Has.hs
+++ b/src/App/Has.hs
@@ -23,6 +23,9 @@ class HasStatsConfig a where
 class HasStoreConfig a where
   storeConfig :: Lens' a StoreConfig
 
+class HasAwsConfig a where
+  awsConfig :: Lens' a AwsConfig
+
 instance HasStatsClient StatsClient where
   statsClient = id
 

--- a/src/App/Has.hs
+++ b/src/App/Has.hs
@@ -20,6 +20,9 @@ class HasKafkaConfig a where
 class HasStatsConfig a where
   statsConfig :: Lens' a StatsConfig
 
+class HasStoreConfig a where
+  storeConfig :: Lens' a StoreConfig
+
 instance HasStatsClient StatsClient where
   statsClient = id
 

--- a/src/App/Has.hs
+++ b/src/App/Has.hs
@@ -17,6 +17,9 @@ class HasStatsClient a where
 class HasKafkaConfig a where
   kafkaConfig :: Lens' a KafkaConfig
 
+class HasStatsConfig a where
+  statsConfig :: Lens' a StatsConfig
+
 instance HasStatsClient StatsClient where
   statsClient = id
 

--- a/src/App/Lens.hs
+++ b/src/App/Lens.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module App.Lens where
+
+import App.Options
+import Control.Lens
+
+makeFields ''KafkaConfig

--- a/src/App/Lens.hs
+++ b/src/App/Lens.hs
@@ -7,3 +7,4 @@ import Control.Lens
 
 makeFields ''KafkaConfig
 makeFields ''StatsConfig
+makeFields ''StoreConfig

--- a/src/App/Lens.hs
+++ b/src/App/Lens.hs
@@ -5,6 +5,7 @@ module App.Lens where
 import App.Options
 import Control.Lens
 
+makeFields ''AwsConfig
 makeFields ''KafkaConfig
 makeFields ''StatsConfig
 makeFields ''StoreConfig

--- a/src/App/Lens.hs
+++ b/src/App/Lens.hs
@@ -6,3 +6,4 @@ import App.Options
 import Control.Lens
 
 makeFields ''KafkaConfig
+makeFields ''StatsConfig

--- a/src/App/Lens.hs
+++ b/src/App/Lens.hs
@@ -7,5 +7,6 @@ import Control.Lens
 
 makeFields ''AwsConfig
 makeFields ''KafkaConfig
+makeFields ''AppOptions
 makeFields ''StatsConfig
 makeFields ''StoreConfig

--- a/src/App/Lens.hs
+++ b/src/App/Lens.hs
@@ -2,9 +2,11 @@
 
 module App.Lens where
 
+import App.AppEnv
 import App.Options
 import Control.Lens
 
+makeFields ''AppEnv
 makeFields ''AwsConfig
 makeFields ''KafkaConfig
 makeFields ''AppOptions

--- a/src/App/Options.hs
+++ b/src/App/Options.hs
@@ -34,10 +34,10 @@ data KafkaConfig = KafkaConfig
   } deriving (Show)
 
 data StatsConfig = StatsConfig
-  { _statsHost       :: HostName
-  , _statsPort       :: Int
-  , _statsTags       :: [StatsTag]
-  , _statsSampleRate :: SampleRate
+  { _statsConfigHost       :: HostName
+  , _statsConfigPort       :: Int
+  , _statsConfigTags       :: [StatsTag]
+  , _statsConfigSampleRate :: SampleRate
   } deriving (Show)
 
 data StoreConfig = StoreConfig
@@ -75,7 +75,6 @@ data DbConfig = DbConfig
   , _dbConfigDatabase :: Text
   } deriving (Eq, Show)
 
-makeClassy ''StatsConfig
 makeClassy ''AwsConfig
 makeClassy ''Options
 makeClassy ''StoreConfig

--- a/src/App/Options.hs
+++ b/src/App/Options.hs
@@ -81,18 +81,6 @@ makeClassy ''AwsConfig
 makeClassy ''Options
 makeClassy ''StoreConfig
 
-instance HasKafkaConfig Options where
-  kafkaConfig = optKafkaConfig
-
-instance HasStatsConfig Options where
-  statsConfig = optStatsConfig
-
-instance HasStoreConfig Options where
-  storeConfig = optStoreConfig
-
-instance HasAwsConfig Options where
-  awsConfig = optAwsConfig
-
 statsConfigParser :: Parser StatsConfig
 statsConfigParser = StatsConfig
   <$> strOption

--- a/src/App/Options.hs
+++ b/src/App/Options.hs
@@ -41,9 +41,9 @@ data StatsConfig = StatsConfig
   } deriving (Show)
 
 data StoreConfig = StoreConfig
-  { _storeBucket         :: BucketName
-  , _storeIndex          :: TableName
-  , _storeUploadInterval :: Seconds
+  { _storeConfigBucket         :: BucketName
+  , _storeConfigIndex          :: TableName
+  , _storeConfigUploadInterval :: Seconds
   } deriving (Show)
 
 data Options = Options
@@ -77,7 +77,6 @@ data DbConfig = DbConfig
 
 makeClassy ''AwsConfig
 makeClassy ''Options
-makeClassy ''StoreConfig
 
 statsConfigParser :: Parser StatsConfig
 statsConfigParser = StatsConfig

--- a/src/App/Options.hs
+++ b/src/App/Options.hs
@@ -24,13 +24,13 @@ import qualified Data.Text as T
 newtype StatsTag = StatsTag (Text, Text) deriving (Show, Eq)
 
 data KafkaConfig = KafkaConfig
-  { _broker                :: BrokerAddress
-  , _schemaRegistryAddress :: String
-  , _pollTimeoutMs         :: Timeout
-  , _queuedMaxMsgKBytes    :: Int
-  , _consumerGroupId       :: ConsumerGroupId
-  , _debugOpts             :: String
-  , _commitPeriodSec       :: Int
+  { _kafkaConfigBroker                :: BrokerAddress
+  , _kafkaConfigSchemaRegistryAddress :: String
+  , _kafkaConfigPollTimeoutMs         :: Timeout
+  , _kafkaConfigQueuedMaxMsgKBytes    :: Int
+  , _kafkaConfigConsumerGroupId       :: ConsumerGroupId
+  , _kafkaConfigDebugOpts             :: String
+  , _kafkaConfigCommitPeriodSec       :: Int
   } deriving (Show)
 
 data StatsConfig = StatsConfig
@@ -75,7 +75,6 @@ data DbConfig = DbConfig
   , _dbConfigDatabase :: Text
   } deriving (Eq, Show)
 
-makeClassy ''KafkaConfig
 makeClassy ''StatsConfig
 makeClassy ''AwsConfig
 makeClassy ''Options

--- a/src/App/Options.hs
+++ b/src/App/Options.hs
@@ -57,8 +57,8 @@ data Options = Options
   } deriving (Show)
 
 data AwsConfig = AwsConfig
-  { _awsRegion     :: Region
-  , _uploadThreads :: Int
+  { _awsConfigRegion        :: Region
+  , _awsConfigUploadThreads :: Int
   } deriving (Show)
 
 newtype Password = Password
@@ -75,7 +75,6 @@ data DbConfig = DbConfig
   , _dbConfigDatabase :: Text
   } deriving (Eq, Show)
 
-makeClassy ''AwsConfig
 makeClassy ''Options
 
 statsConfigParser :: Parser StatsConfig

--- a/src/App/Persist.hs
+++ b/src/App/Persist.hs
@@ -10,7 +10,7 @@ import Antiope.DynamoDB              (TableName, attributeValue, avN, avS, dynam
 import Antiope.S3                    (BucketName (..), ObjectKey (..), S3Location (..), putFile)
 import App.AppState.Type             (FileCache (..), FileCacheEntry (..), fileCacheEmpty)
 import App.CancellationToken         (CancellationToken)
-import App.Options                   (HasAwsConfig (..), HasStoreConfig (..), awsConfig, uploadThreads)
+import App.Options                   (HasAwsConfig (..), awsConfig, uploadThreads)
 import App.ToSha256Text              (toSha256Text)
 import Control.Concurrent.Async.Pool (mapTasks, withTaskGroup)
 import Control.Lens                  (use, view, (&), (.=), (?~), (^.))
@@ -29,6 +29,8 @@ import Kafka.Consumer                (Millis (..), Offset (..), PartitionId (..)
 
 import qualified App.AppState.Lens     as L
 import qualified App.CancellationToken as CToken
+import qualified App.Has               as H
+import qualified App.Lens              as L
 import qualified Data.ByteString.Lazy  as LBS
 import qualified Data.HashMap.Strict   as Map
 import qualified System.IO.Streams     as IO
@@ -37,7 +39,7 @@ import qualified System.IO.Streams     as IO
 -- The file handles will be closed and files must not be used after this function returns.
 -- The FileCache will be emptied in State.
 uploadAllFiles :: ( MonadState s m, L.HasFileCache s FileCache
-                  , MonadReader r m, HasAwsConfig r, HasStoreConfig r
+                  , MonadReader r m, HasAwsConfig r, H.HasStoreConfig r
                   , HasEnv r, MonadAWS m)
                => CancellationToken
                -> UTCTime
@@ -50,15 +52,15 @@ uploadAllFiles ctoken timestamp = do
   where closeEntry e = IO.write Nothing (e ^. L.outputStream) >> pure e
 
 uploadFiles :: ( MonadAWS m, HasEnv r
-               , MonadReader r m, HasAwsConfig r, HasStoreConfig r)
+               , MonadReader r m, HasAwsConfig r, H.HasStoreConfig r)
             => CancellationToken
             -> UTCTime
             -> [FileCacheEntry]
             -> m ()
 uploadFiles ctoken timestamp fs = do
   aws <- ask
-  bkt <- view storeBucket
-  tbl <- view storeIndex
+  bkt <- view $ H.storeConfig . L.bucket
+  tbl <- view $ H.storeConfig . L.index
   par <- view (awsConfig . uploadThreads)
   liftIO . void $ mapConcurrently' par (go aws bkt tbl) fs
   where


### PR DESCRIPTION
Explicitly declare `Has` typeclasses in separate `App.Has` module.

This allows us to easily convert to use `makeField` style lenses instead.

As it turns out, declaring `makeClassy` fields does what the `Has` typeclasses do and more, so it actually makes sense to use that as well, but put it in the `Has` module.

Then in our code, we actually have a choice:

```
import qualified App.Has  as H
import qualified App.Lens as L
```